### PR TITLE
Adjust header scale and contact spacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+build/

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -2,7 +2,7 @@
 export default function Contact() {
   return (
     <section id="contact" className="bg-gray-50">
-      <div className="container py-16">
+      <div className="container pt-16 pb-12 md:pb-16">
         <h2 className="text-2xl font-bold">Contact</h2>
         <div className="mt-6 grid gap-6 md:grid-cols-3">
           <div className="card p-4">
@@ -33,7 +33,7 @@ export default function Contact() {
             </div>
           </div>
         </div>
-        <div className="mt-6">
+        <div className="mt-8 space-y-4">
           <iframe
             title="Sri Lakshmi Power Printers Map"
             className="w-full h-72 rounded-2xl border"
@@ -41,11 +41,11 @@ export default function Contact() {
             referrerPolicy="no-referrer-when-downgrade"
             src="https://www.google.com/maps?q=No.12,+Denkanikottai+Rd,+Prakash+Nagar,+Hosur,+Tamil+Nadu+635109&output=embed"
           ></iframe>
+          <p className="text-center text-xs text-gray-500">
+            © {new Date().getFullYear()} Sri Lakshmi Power Printers. All rights
+            reserved.
+          </p>
         </div>
-        <p className="mt-6 text-xs text-gray-500">
-          © {new Date().getFullYear()} Sri Lakshmi Power Printers. All rights
-          reserved.
-        </p>
       </div>
       {/* <button
         id="kollect-pay-btn"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,15 +12,15 @@ export default function Header() {
   ];
   return (
     <header className="relative header-diagonal header-ribbon header-glass border-b">
-      <div className="container flex items-center justify-between py-4">
+      <div className="container flex items-center justify-between py-5 md:py-6">
         <a
           href="#home"
-          className="flex items-center gap-2 font-semibold text-sm md:text-base"
+          className="flex items-center gap-3 font-semibold text-base sm:text-lg md:text-xl"
         >
           <img
             src={logo}
             alt="Sri Lakshmi Power Printers"
-            className="h-12 w-12 md:h-14 md:w-14 rounded-xl border object-contain bg-transparent"
+            className="h-14 w-14 sm:h-16 sm:w-16 md:h-[4.5rem] md:w-[4.5rem] rounded-xl border object-contain bg-transparent"
             onError={(e) => {
               e.currentTarget.outerHTML =
                 '<svg width="36" height="36" viewBox="0 0 24 24" aria-hidden fill="currentColor"><path d="M5 3h14v4H5zM3 9h18v4H3zM5 15h14v6H5z"/></svg>';
@@ -33,13 +33,16 @@ export default function Header() {
             <a
               key={href}
               href={href}
-              className="text-sm text-gray-700 hover:text-black"
+              className="text-base font-medium text-gray-700 hover:text-black"
             >
               {label}
             </a>
           ))}
         </nav>
-        <a href="#enquiry" className="btn btn-primary">
+        <a
+          href="#enquiry"
+          className="btn btn-primary !px-5 !py-2.5 !text-base"
+        >
           Get a Quote
         </a>
       </div>


### PR DESCRIPTION
## Summary
- increase the header logo, typography and spacing so the branding feels larger
- tighten the contact section spacing by grouping the map and copyright text
- add a .gitignore so build artifacts and dependencies stay untracked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95fb152ac8320baf4dd6995b46b45